### PR TITLE
improvement: DREL-262 add ip geolocation search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 .idea
 node_modules
+.vscode

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,8 @@ export default [
     {
         ignores: [
             'node_modules/**',
-            'dist/**'
+            'dist/**',
+            'public/**'
         ]
     },
     ...streamr,
@@ -57,7 +58,7 @@ export default [
                 multiline: { delimiter: 'none' }
             }],
             '@stylistic/object-curly-spacing': ['error', 'always'],
-            '@typescript-eslint/restrict-template-expressions': ['error', { 
+            '@typescript-eslint/restrict-template-expressions': ['error', {
                 allowAny: false,
                 allowBoolean: true,
                 allowNullish: true,

--- a/public/main.js
+++ b/public/main.js
@@ -87,11 +87,11 @@ function showNodeDetails(node) {
     let detailsHTML = `
             <p><strong>Node ID:</strong> ${node.id}</p>
             <p><strong>IP Address:</strong> ${node.ipAddress || 'N/A'}</p>
-            <p><strong>Country:</strong> ${node?.location?.country || 'N/A'}</p>
+            <p><strong>Location:</strong> ${(node?.location?.country || 'N/A') + '/' + (node?.location?.city || 'N/A')}</p>
+            <p><strong>Region:</strong> ${node.region || 'N/A'}</p>
             <p><strong>Application version:</strong> ${node.applicationVersion}</p>
             <p><strong>Websocket URL:</strong> ${node.websocketUrl || 'N/A'}</p>
             <p><strong>Node type:</strong> ${node.nodeType}</p>
-            <p><strong>Region:</strong> ${node.region || 'N/A'}</p>
             <p><strong>Neighbor count:</strong> ${node.neighbors ? node.neighbors.length : 0}</p>
             <p><strong>Control layer neighbor count:</strong> ${node.controlLayerNeighborCount}</p>
             <p><strong>All stream partiions:</strong> ${node.allStreamPartitions.join(',<br>')}</p>

--- a/public/main.js
+++ b/public/main.js
@@ -87,6 +87,7 @@ function showNodeDetails(node) {
     let detailsHTML = `
             <p><strong>Node ID:</strong> ${node.id}</p>
             <p><strong>IP Address:</strong> ${node.ipAddress || 'N/A'}</p>
+            <p><strong>Country:</strong> ${node?.location?.country || 'N/A'}</p>
             <p><strong>Application version:</strong> ${node.applicationVersion}</p>
             <p><strong>Websocket URL:</strong> ${node.websocketUrl || 'N/A'}</p>
             <p><strong>Node type:</strong> ${node.nodeType}</p>
@@ -126,9 +127,9 @@ if (!streamId) {
     }, 1000);
 
     // Fetch topology data from localhost with streamId as a query parameter
-    fetch(`/topology?streamId=${streamId}`).then(function(response) {
+    fetch(`/topology?streamId=${streamId}`).then(function (response) {
         return response.json()
-    }).then(function(data) {
+    }).then(function (data) {
         // Remove loading indicator
         document.getElementById('loading').style.display = 'none';
         clearInterval(timerInterval);
@@ -136,7 +137,7 @@ if (!streamId) {
         // Build nodes and links
         const nodes = [];
         const nodeById = new Map();
-        data.forEach(function(d) {
+        data.forEach(function (d) {
             const node = {
                 id: d.id,
                 ipAddress: d.ipAddress,
@@ -146,7 +147,8 @@ if (!streamId) {
                 region: d.region,
                 neighbors: d.neighbors,
                 controlLayerNeighborCount: d.controlLayerNeighborCount,
-                allStreamPartitions: d.allStreamPartitions
+                allStreamPartitions: d.allStreamPartitions,
+                location: d.location
             };
             nodes.push(node);
             nodeById.set(d.id, node);
@@ -155,9 +157,9 @@ if (!streamId) {
         // Update the global links array instead of creating a new one
         links = [];
         const linkSet = new Set();
-        data.forEach(function(d) {
+        data.forEach(function (d) {
             const sourceId = d.id;
-            d.neighbors.forEach(function(targetId) {
+            d.neighbors.forEach(function (targetId) {
                 const key = [sourceId, targetId].sort().join("-");
                 if (!linkSet.has(key)) {
                     linkSet.add(key);
@@ -252,7 +254,7 @@ if (!streamId) {
 
         // Initialize the simulation
         const simulation = d3.forceSimulation(nodes)
-            .force("link", d3.forceLink(links).id(function(d) { return d.id; }).distance(100))
+            .force("link", d3.forceLink(links).id(function (d) { return d.id; }).distance(100))
             .force("charge", d3.forceManyBody().strength(-300))
             .force("center", d3.forceCenter(width / 2, height / 2));
 
@@ -274,7 +276,7 @@ if (!streamId) {
         const circles = node.append("circle")
             .attr("r", 10)
             .attr("fill", "blue")
-            .on("click", function(event, d) {
+            .on("click", function (event, d) {
                 event.stopPropagation();
                 showNodeDetails(d);
             });
@@ -282,9 +284,9 @@ if (!streamId) {
         // Add labels to nodes
         const labels = node.append("text")
             .attr("dy", -15)
-            .text(function(d) {
+            .text(function (d) {
                 if (d.ipAddress) {
-                    return d.id.substring(0, 4) + "..." + d.id.substring(d.id.length - 4) + " (" + d.ipAddress + ")";
+                    return d.id.substring(0, 4) + "..." + d.id.substring(d.id.length - 4) + " (" + d.ipAddress + ")" + " (" + d.location?.country + "/" + d.location?.city + ")";
                 } else {
                     return d.id.substring(0, 6);
                 }
@@ -294,7 +296,7 @@ if (!streamId) {
 
         // Add tooltips to display full node ID and IP address
         node.append("title")
-            .text(function(d) {
+            .text(function (d) {
                 return "Node ID: " + d.id + "\nIP Address: " + (d.ipAddress ? d.ipAddress : "N/A");
             });
 
@@ -309,7 +311,7 @@ if (!streamId) {
         let highlightedLinks = new Set();
 
         // Add click event to the SVG background to reset highlighting
-        svg.on("click", function(event) {
+        svg.on("click", function (event) {
             if (event.target === svg.node()) {
                 resetHighlighting();
                 closeNodeDetails();
@@ -333,13 +335,13 @@ if (!streamId) {
         // Update positions on each tick of the simulation
         simulation.on("tick", () => {
             link
-                .attr("x1", function(d) { return d.source.x; })
-                .attr("y1", function(d) { return d.source.y; })
-                .attr("x2", function(d) { return d.target.x; })
-                .attr("y2", function(d) { return d.target.y; });
+                .attr("x1", function (d) { return d.source.x; })
+                .attr("y1", function (d) { return d.source.y; })
+                .attr("x2", function (d) { return d.target.x; })
+                .attr("y2", function (d) { return d.target.y; });
 
             node
-                .attr("transform", function(d) {
+                .attr("transform", function (d) {
                     return "translate(" + d.x + "," + d.y + ")";
                 });
         });

--- a/public/main.js
+++ b/public/main.js
@@ -141,14 +141,14 @@ if (!streamId) {
             const node = {
                 id: d.id,
                 ipAddress: d.ipAddress,
+                location: d.location,
+                region: d.region,
                 applicationVersion: d.applicationVersion,
                 websocketUrl: d.websocketUrl,
                 nodeType: d.nodeType,
-                region: d.region,
                 neighbors: d.neighbors,
                 controlLayerNeighborCount: d.controlLayerNeighborCount,
                 allStreamPartitions: d.allStreamPartitions,
-                location: d.location
             };
             nodes.push(node);
             nodeById.set(d.id, node);

--- a/src/Topology.ts
+++ b/src/Topology.ts
@@ -20,12 +20,12 @@ export interface Node {
 export class Topology {
     private nodes: Map<DhtAddress, Node> = new Map()
 
-    private constructor(infos: NormalizedNodeInfo[]) {
+    private constructor() {
         this.nodes = new Map()
     }
 
     public static async create(infos: NormalizedNodeInfo[]): Promise<Topology> {
-        const topology = new Topology(infos)
+        const topology = new Topology()
         const nodeIds = new Set(...[infos.map((info) => toNodeId(info.peerDescriptor))])
         await Promise.all(infos.map((info) => topology.initializeNode(info, nodeIds)))
         return topology
@@ -50,7 +50,7 @@ export class Topology {
             ? numberToIpv4(info.peerDescriptor.ipAddress)
             : undefined
 
-        let node: Node = {
+        const node: Node = {
             id: nodeId,
             applicationVersion: info.applicationVersion,
             websocketUrl,

--- a/src/crawlTopology.ts
+++ b/src/crawlTopology.ts
@@ -82,5 +82,7 @@ export const crawlTopology = async (
     }
 
     logger.info(`Topology crawled`, { runId, timeTaken: Date.now() - startTime, nodeCount: nodeInfos.size, errorCount: errorNodes.size })
-    return new Topology([...nodeInfos.values()])
+    const topology = await Topology.create([...nodeInfos.values()])
+    return topology
+    //return new Topology([...nodeInfos.values()])
 }

--- a/src/crawlTopology.ts
+++ b/src/crawlTopology.ts
@@ -84,5 +84,4 @@ export const crawlTopology = async (
     logger.info(`Topology crawled`, { runId, timeTaken: Date.now() - startTime, nodeCount: nodeInfos.size, errorCount: errorNodes.size })
     const topology = await Topology.create([...nodeInfos.values()])
     return topology
-    //return new Topology([...nodeInfos.values()])
 }

--- a/src/fetchLocationData.ts
+++ b/src/fetchLocationData.ts
@@ -1,0 +1,35 @@
+import { Logger } from '@streamr/utils'
+
+const logger = new Logger(module)
+
+interface LocationData {
+    city?: string
+    country?: string
+    loc?: string
+    hostname?: string
+    org?: string
+    postal?: string
+    timezone?: string
+}
+
+export async function fetchLocationData(ipAddress: string): Promise<LocationData> {
+    try {
+        const response = await fetch(`https://ipinfo.io/${ipAddress}?token=29de457f326044`)
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`)
+        }
+        const data = await response.json() as any
+        return {
+            city: data?.city,
+            country: data?.country,
+            loc: data?.loc,
+            hostname: data?.hostname,
+            org: data?.org,
+            postal: data?.postal,
+            timezone: data?.timezone,
+        }
+    } catch (err) {
+        logger.warn('Failed to fetch location data', { err, ipAddress })
+        return {}
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "stripInternal": true,
     "strictBindCallApply": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "sourceMap": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
Pros:
Adds 3rd party geolocation search (https://ipinfo.io/) to nodes. 
Attempts to request location data, if it fails it won't be added to the node data.
Enables us to do geographic filtering of nodes and geo layout of the graph in future.

Cons:
Reliance to 3rd party service.
Uses freemium tier, 30k requests per month. 